### PR TITLE
minをmaxに変更

### DIFF
--- a/tutorial/02_demo_app.md
+++ b/tutorial/02_demo_app.md
@@ -360,7 +360,7 @@ changeset/2‚ÌŠÖ”‚ª‚ ‚è‚Ü‚·‚ËB
 def changeset(model, params \\ :empty) do
   model
   |> cast(params, @required_fields, @optional_fields)
-  |> validate_length(:content, min: 140) # Additional lines
+  |> validate_length(:content, max: 140) # Additional lines
 end
 ```
 


### PR DESCRIPTION
こんにちは。
チュートリアル勧めさせていただいております。

> ファイル: web/models/micropost.ex
> changeset/2の関数がありますね。
> 内容を以下のように編集して下さい。
> (Additional linesの部分)
> 
> ```
> def changeset(model, params \\ :empty) do
>   model
>   |> cast(params, @required_fields, @optional_fields)
>   |> validate_length(:content, min: 140) # Additional lines
> end
> ```
> 
> 何をやったのか？
> マイクロポストの投稿において、140文字の制限を加えました。

の箇所についてですが、min:140の場合140文字以下で以下のエラーが発生しています。

```
Oops, something went wrong! Please check the errors below:
Content should be at least 140 characters
```

正しくはmaxではないかと思います。

Phoenixバージョンは1.00です。
